### PR TITLE
DRAFT: work on fixing streaming from event hub to azure data lake gen 2 

### DIFF
--- a/internal/services/eventhub/eventhub_resource.go
+++ b/internal/services/eventhub/eventhub_resource.go
@@ -118,9 +118,7 @@ func resourceEventHub() *pluginsdk.Resource {
 										Required: true,
 										ValidateFunc: validation.StringInSlice([]string{
 											"EventHubArchive.AzureBlockBlob",
-											// TODO: support `EventHubArchive.AzureDataLake` once supported in the Swagger / SDK
-											// https://github.com/Azure/azure-rest-api-specs/issues/2255
-											// BlobContainerName & StorageAccountID can then become Optional
+											"EventHubArchive.AzureDataLake",
 										}, false),
 									},
 									"archive_name_format": {
@@ -130,11 +128,11 @@ func resourceEventHub() *pluginsdk.Resource {
 									},
 									"blob_container_name": {
 										Type:     pluginsdk.TypeString,
-										Required: true,
+										Optional: true,
 									},
 									"storage_account_id": {
 										Type:         pluginsdk.TypeString,
-										Required:     true,
+										Optional: true,
 										ValidateFunc: commonids.ValidateStorageAccountID,
 									},
 								},


### PR DESCRIPTION
Does not work yet 
'DataLakeSubscriptionId' is null or empty.
DataLakeSubscriptionId needs to be added to Azure API call

azure doc
https://learn.microsoft.com/en-us/rest/api/eventhub/event-hubs/create-or-update?view=rest-eventhub-2024-01-01&tabs=HTTP#destination